### PR TITLE
the Graph character class included spaces (\x20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,9 +240,9 @@ common atoms, corresponding to POSIX character classes:
   Blank  <- {' ','\t'},                   # Space and tab
   Cntrl  <- {'\x00'..'\x1f','\x7f'},      # Control characters
   Digit  <- {'0'..'9'},                   # Digits
-  Graph  <- {'\x20'..'\x7e'},             # Visible characters
+  Graph  <- {'\x21'..'\x7e'},             # Visible characters
   Lower  <- {'a'..'z'},                   # Lowercase characters
-  Print  <- {'\x20'..'\x7e',' '},         # Visible characters and spaces
+  Print  <- {'\x21'..'\x7e',' '},         # Visible characters and spaces
   Space  <- {'\9'..'\13',' '},            # Whitespace characters
   Upper  <- {'A'..'Z'},                   # Uppercase characters
   Xdigit <- {'A'..'F','a'..'f','0'..'9'}, # Hexadecimal digits

--- a/src/npeg/buildpatt.nim
+++ b/src/npeg/buildpatt.nim
@@ -50,9 +50,9 @@ const builtins = {
   "Blank":  newPatt({' ','\t'}),                   # Space and tab
   "Cntrl":  newPatt({'\x00'..'\x1f','\x7f'}),      # Control characters
   "Digit":  newPatt({'0'..'9'}),                   # Digits
-  "Graph":  newPatt({'\x20'..'\x7e'}),             # Visible characters
+  "Graph":  newPatt({'\x21'..'\x7e'}),             # Visible characters
   "Lower":  newPatt({'a'..'z'}),                   # Lowercase characters
-  "Print":  newPatt({'\x20'..'\x7e',' '}),         # Visible characters and spaces
+  "Print":  newPatt({'\x21'..'\x7e',' '}),         # Visible characters and spaces
   "Space":  newPatt({'\9'..'\13',' '}),            # Whitespace characters
   "Upper":  newPatt({'A'..'Z'}),                   # Uppercase characters
   "Xdigit": newPatt({'A'..'F','a'..'f','0'..'9'}), # Hexadecimal digits

--- a/tests/basics.nim
+++ b/tests/basics.nim
@@ -91,6 +91,7 @@ suite "unit tests":
     doAssert     patt(Lower).match("A").ok == false
     doAssert     patt(+Digit).match("12345").ok
     doAssert     patt(+Xdigit).match("deadbeef").ok
+    doAssert     patt(+Graph).match(" x").ok == false
 
   test "Compile time":
     proc dotest(): string {.compileTime.} =


### PR DESCRIPTION
0x20 is actually ' ' (confirm with `man ascii`), so Graph included it erroneously, and Print included it redundantly. I've changed both classes to start at 0x21, and added a test to confirm that +Graph won't match a string beginning with a space.