### PR TITLE
Allow capturing on the LHS of a rule definition

### DIFF
--- a/src/npeg/parsepatt.nim
+++ b/src/npeg/parsepatt.nim
@@ -190,14 +190,13 @@ proc parseGrammar*(ns: NimNode, dot: Dot=nil, dumpRailroad = true): Grammar =
 
       case n[1].kind
       of nnkIdent, nnkDotExpr, nnkPrefix:
-        let isCaptureDef = n[1].kind == nnkPrefix
-        if isCaptureDef: expectIdent n[1][0], ">"
-        let name = if isCaptureDef: n[1][1].repr else: n[1].repr
+        let name = if n[1].kind == nnkPrefix: expectIdent n[1][0], ">"; n[1][1].repr
+                   else: n[1].repr
         var patt = parsePatt(name, n[2], result, dot)
         if n.len == 4:
           patt = newPatt(patt, ckAction)
           patt[patt.high].capAction = n[3]
-        result.addRule name, if isCaptureDef: >patt else: patt
+        result.addRule name, if n[1].kind == nnkPrefix: >patt else: patt
 
         when npegGraph:
           if dumpRailroad:

--- a/src/npeg/parsepatt.nim
+++ b/src/npeg/parsepatt.nim
@@ -188,7 +188,8 @@ proc parseGrammar*(ns: NimNode, dot: Dot=nil, dumpRailroad = true): Grammar =
 
     if n.kind == nnkInfix and n[0].eqIdent("<-"):
 
-      if n[1].kind in { nnkIdent, nnkDotExpr}:
+      case n[1].kind
+      of nnkIdent, nnkDotExpr:
         let name = n[1].repr
         var patt = parsePatt(name, n[2], result, dot)
         if n.len == 4:
@@ -200,7 +201,20 @@ proc parseGrammar*(ns: NimNode, dot: Dot=nil, dumpRailroad = true): Grammar =
           if dumpRailroad:
             echo parseRailroad(n[2], result).wrap(name)
 
-      elif n[1].kind == nnkCall:
+      of nnkPrefix:
+        expectIdent n[1][0], ">"
+        let name = n[1][1].repr
+        var patt = parsePatt(name, n[2], result, dot)
+        if n.len == 4:
+          patt = newPatt(patt, ckAction)
+          patt[patt.high].capAction = n[3]
+        result.addRule name, >patt
+
+        when npegGraph:
+          if dumpRailroad:
+            echo parseRailroad(n[2], result).wrap(name)
+
+      of nnkCall:
         if n.len > 3:
           error "Code blocks can not be used on templates", n[3]
         var t = Template(name: n[1][0].strVal, code: n[2])

--- a/tests/captures.nim
+++ b/tests/captures.nim
@@ -2,6 +2,7 @@ import unittest
 import npeg
 import strutils
 import json
+import tables
   
 {.push warning[Spacing]: off.}
 
@@ -87,3 +88,23 @@ suite "captures":
       foo <- >(>1 * b)
       b <- >1: push $1
     doAssert p.match("ab").captures() == @["ab", "a", "b"]
+
+  test "left-hand side captures":
+    let p = peg "m":
+      m <- n * '+' * n:
+        push $(parseInt($1) + parseInt($2))
+      >n <- +Digit
+    let r = p.match("12+34")
+    doAssert r.captures()[0] == "46"
+
+  test "left-hand side captures 2":
+    var words: Table[string, int]
+
+    let parser = peg "pairs":
+      pairs <- pair * *(',' * pair) * !1
+      >word <- +Alpha
+      number <- +Digit
+      pair <- word * '=' * >number:
+        words[$1] = parseInt($2)
+
+    doAssert parser.match("one=1,two=2,three=3,four=4").ok


### PR DESCRIPTION
 The tests inlcude a few examples; this might seem like a weird extension, but I feel like this helps with readability in some cases since you can tell what is being captured just by looking at the LHS of the PEG.