### PR TITLE
mixin repr in dumpSubject

### DIFF
--- a/src/npeg/common.nim
+++ b/src/npeg/common.nim
@@ -256,6 +256,7 @@ proc dumpSubject*[S](s: openArray[S], o:int=0, l:int=1024): string =
     when S is char:
       let a = escapeChar s[i]
     else:
+      mixin repr
       let a = s[i].repr
     if result.len >= l-a.len:
       return


### PR DESCRIPTION
This is to allow the user to override the `repr` in npegTrace with their own version. `system.repr` completely blows the trace up when the user uses a type that's not trivial (such as an object). For instance, the following type:
```nim
  TokenKind* = enum
    tkNumber = "number"
    tkIdent = "ident"

  Token* = object
    line*: int
    case kind*: TokenKind
    of tkNumber: number*: float
    of tkIdent: ident*: string
```
Results in traces looking like this:
```
 12|  0|  6|[line = 1,
{]           |call           |  capopen ckAction -> 6                 |**
 13|  0|  6|[line = 1,
{]           |callOp         |   capopen ckAction -> 6                |**
 14|  0|  6|[line = 1,
{]           |callOp         |    lit :                               |**
180|  0|  6|[line = 1,
{]           |               |opFail (backtrack)                      |**
 27|  0|  6|[line = 1,
{]           |show           | capopen ckAction -> 6                  |*
 28|  0|  6|[line = 1,
{]           |show           |  capopen ckVal -> 6                    |*
 29|  0|  6|[line = 1,
{]           |show           |   choice 32                            |*
 30|  0|  6|[line = 1,
{]           |show           |    lit !                               |**
```
due to `system.repr` inserting newlines wherever it wants. This PR allows the user to declare their own repr, like so:
```nim
proc repr(t: Token) = $t.kind  # or something. the user decides!
```