### PR TITLE
Check if traces can be popped from exceptions

### DIFF
--- a/src/npeg/codegen.nim
+++ b/src/npeg/codegen.nim
@@ -347,7 +347,7 @@ proc genExceptionCode(ms, ip, symTab: NimNode): NimNode =
       aux(`ms`.retStack.pop())
 
     let e = getCurrentException()
-    when compiles(e.trace):
+    when compiles(e.trace.pop()):
       # drop the generated parser fn() from the trace and replace by the NPeg frames
       discard e.trace.pop()
       e.trace.add trace


### PR DESCRIPTION
I have strange problem with manipulating `Exception.trace` that gives me this error:
```
preserves-nim/src/preserves/private/parse.nim(82, 24) template/generic instantiation of `peg` from here
npeg/src/npeg/codegen.nim(440, 55) template/generic instantiation of `fn_run`gensym730` from here
npeg/src/npeg/codegen.nim(352, 16) Error: expression 'discard' has no type (or is ambiguous)
```

The code that causes this problem is [here](https://git.syndicate-lang.org/ehmry/preserves-nim/src/branch/trunk/src/preserves/private/parse.nim) but only when it is imported elsewhere.