### PR TITLE
Avoid the OS if possible

### DIFF
--- a/src/npeg.nim
+++ b/src/npeg.nim
@@ -61,7 +61,6 @@ import tables
 import macros
 import strutils
 import npeg/[common,codegen,capture,parsepatt,grammar,dot]
-import os
 
 export NPegException, contains, `[]`, len
 
@@ -146,7 +145,7 @@ proc match*[S](p: Parser, s: openArray[S]): MatchResult[S] =
 # Match a file
 
 when defined(windows) or defined(posix):
-  import memfiles
+  import memfiles, os
   proc matchFile*[T](p: Parser, fname: string, userData: var T): MatchResult[char] =
     # memfiles.open() throws on empty files, work around that
     if os.getFileSize(fname) > 0:

--- a/src/npeg/dot.nim
+++ b/src/npeg/dot.nim
@@ -35,7 +35,7 @@ proc addPatt*(d: Dot, name: string, len: int) =
 
 proc dump*(d: Dot) =
   const npegDotDir {.strdefine.}: string = ""
-  if npegDotDir != "":
+  when npegDotDir != "":
     let fname = npegDotDir & "/" & d.name & ".dot"
     echo "Dumping dot graph file to " & fname & "..."
 


### PR DESCRIPTION
Do not import the os module or attempt to create files unless compile-time conditionals indicate that the platform supports it or the behavior is requested from a define. This allows Npeg to be built for platforms without access to an OS.