### PR TITLE
Fix [BareExcept] warning when compiling with Nim #devel

### DIFF
--- a/src/npeg/codegen.nim
+++ b/src/npeg/codegen.nim
@@ -418,7 +418,7 @@ proc genCode*(program: Program, sType, uType, uId: NimNode): NimNode =
       try:
         `traceCode`
         `loopCode`
-      except:
+      except CatchableError:
         `exceptionCode`
 
       # When the parsing machine is done, copy the local copies of the


### PR DESCRIPTION
For details see <https://github.com/nim-lang/Nim/commit/91ce8c385d4ccbaab8048cf0393b01cd72282272>.