### PR TITLE
RFC: Unicode concat operator

### DIFF
--- a/src/npeg/parsepatt.nim
+++ b/src/npeg/parsepatt.nim
@@ -115,7 +115,7 @@ proc parsePatt*(pattName: string, nn: NimNode, grammar: Grammar, dot: Dot = nil)
 
       of nnkInfix:
         case n[0].strVal:
-          of "*": result = aux(n[1]) * aux(n[2])
+          of "*", "∙": result = aux(n[1]) * aux(n[2])
           of "-": result = aux(n[1]) - aux(n[2])
           of "^": result = newPattAssoc(aux(n[1]), intVal(n[2]), assocLeft)
           of "^^": result = newPattAssoc(aux(n[1]), intVal(n[2]), assocRight)

--- a/src/npeg/railroad.nim
+++ b/src/npeg/railroad.nim
@@ -281,7 +281,7 @@ proc parseRailRoad*(nn: NimNode, grammar: Grammar): Node =
 
       of nnkInfix:
         case n[0].strVal:
-          of "*": result = aux(n[1]) * aux(n[2])
+          of "*", "∙": result = aux(n[1]) * aux(n[2])
           of "-": result = aux(n[1]) - aux(n[2])
           of "^": result = newPrecNode(aux(n[1]), intVal(n[2]), "<")
           of "^^": result = newPrecNode(aux(n[1]), intVal(n[2]), ">")


### PR DESCRIPTION
I personally find using '*' for concatenation visually "noisy". I understand an operator with the right precedence is required and so I went looking for an alternative that would not look like _zero or more_ '*'. This PR implements support for `\bullet` (`∙`) because it is listed among Unicode operators here <https://nim-lang.org/docs/manual.html#lexical-analysis-unicode-operators>. I also tried adding `\cdot` (`⋅`), which seems more appropriate because it is normally used as concatenation symbol in math script, but it currently won't work.

Not sure if this is something you would be interested in merging but it works and maybe someone else will find it useful.