### PR TITLE
Fixes for --styleCheck=usages

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -1,0 +1,5 @@
+--styleCheck:usages
+if (NimMajor, NimMinor) < (1, 6):
+  --styleCheck:hint
+else:
+  --styleCheck:error

--- a/src/npeg/capture.nim
+++ b/src/npeg/capture.nim
@@ -39,7 +39,7 @@ proc findTop[S](capStack: var Stack[CapFrame[S]], fm: FixMethod): int =
 proc fixCaptures*[S](s: openArray[S], capStack: var Stack[CapFrame[S]], fm: FixMethod): Captures[S] =
 
   assert capStack.top > 0
-  assert capStack.peek.cft == cftCLose
+  assert capStack.peek.cft == cftClose
   when npegDebug: echo $capStack
 
   # Convert the closed frames to a seq[Capture]
@@ -84,7 +84,7 @@ proc collectCapturesRef*(caps: Captures): Ref =
 proc getCapture[S](cs: Captures[S], i: int): Capture[S] =
   if i >= cs.capList.len:
     let msg = "Capture out of range, " & $i & " is not in [0.." & $cs.capList.high & "]"
-    raise newException(NpegCaptureOutOfRangeError, msg)
+    raise newException(NPegCaptureOutOfRangeError, msg)
   cs.capList[i]
 
 proc `[]`*[S](cs: Captures[S], i: int): Capture[S] =

--- a/src/npeg/codegen.nim
+++ b/src/npeg/codegen.nim
@@ -35,7 +35,7 @@ type
 
   Parser*[S, T] = object
     fn_init*: proc(): MatchState[S]
-    when npegGcSafe:
+    when npegGcsafe:
       fn_run*: proc(ms: var MatchState[S], s: openArray[S], u: var T): MatchResult[S] {.gcsafe.}
     else:
       fn_run*: proc(ms: var MatchState[S], s: openArray[S], u: var T): MatchResult[S]
@@ -352,7 +352,7 @@ proc genExceptionCode(ms, ip, si, simax, symTab: NimNode): NimNode =
       e.trace.add trace
 
     # Re-reaise the exception with the augmented stack trace and match index filled in
-    if e of NpegException:
+    if e of NPegException:
       let eref = (ref NPegException)(e)
       eref.matchLen = `si`
       eref.matchMax = `simax`

--- a/src/npeg/common.nim
+++ b/src/npeg/common.nim
@@ -313,7 +313,7 @@ proc `$`*(i: Inst, ip=0): string =
 
 proc `$`*(program: Program): string =
   for ip, i in program.patt.pairs:
-    if ip in program.symtab:
+    if ip in program.symTab:
       result.add "\n" & program.symTab[ip].repr & "\n"
     result.add align($ip, 4) & ": " & `$`(i, ip) & "\n"
 

--- a/tests/basics.nim
+++ b/tests/basics.nim
@@ -28,7 +28,7 @@ suite "unit tests":
     doAssert     patt("").match("abcde").matchLen == 0
     doAssert     patt("a").match("abcde").matchLen == 1
     doAssert     patt("ab").match("abcde").matchLen == 2
-    doassert     patt(i"ab").match("AB").ok
+    doAssert     patt(i"ab").match("AB").ok
 
   test "*: concatenation":
     doAssert     patt("a" * "b").match("ab").ok
@@ -114,7 +114,7 @@ suite "unit tests":
     doAssert     patt('a' | ('b' * 'c') | ('d' * 'e' * 'f')).match("def").ok
 
   test "Compile time 1":
-    proc dotest(): string {.compileTime.} =
+    proc doTest(): string {.compileTime.} =
       var n: string
       let p = peg "number":
         number <- >+Digit:

--- a/tests/captures.nim
+++ b/tests/captures.nim
@@ -30,14 +30,14 @@ suite "captures":
       foo <- >1: v = $1
     var a: string
     doAssert p.match("a", a).ok
-    doassert a == "a"
+    doAssert a == "a"
   
   test "code block captures 3":
     var a: string
     let p = patt >1:
         a = $1
     doAssert p.match("a").ok
-    doassert a == "a"
+    doAssert a == "a"
   
   test "code block captures 4":
     let p = peg "foo":

--- a/tests/lexparse.nim
+++ b/tests/lexparse.nim
@@ -10,7 +10,7 @@ type
   Node = ref object
     case kind: Token
     of tInt:
-      intval: int
+      intVal: int
     of tAdd:
       discard
     of cAddExpr:
@@ -35,7 +35,7 @@ let lexer = peg(tokens, st: State):
   tokens <- s * *(token * s)
   token  <- int | add
   int    <- +Digit:
-    st.tokens.add Node(kind: tInt, intval: parseInt($0))
+    st.tokens.add Node(kind: tInt, intVal: parseInt($0))
   add    <- '+':
     st.tokens.add Node(kind: tAdd)
 


### PR DESCRIPTION
--styleCheck=usages allows to check that the nim ident are used consistently.
I went ahead and enabled them for the entire repo & fixed where necessary

But if you don't want that (which I completely understand), the only fix actually needed to use npeg in a `--styleCheck=usages` project is `when npegGcsafe:` because that's in a generic and the compiler doesn't like that

Please let me know if you like it as-is, or want the "minimal fix"